### PR TITLE
Comment out contact and summary example prompts

### DIFF
--- a/app.py
+++ b/app.py
@@ -731,8 +731,8 @@ gr.ChatInterface(
     description="Ask anything about Priyanshu Khandelwal.",
     examples=[
         # ["What are your hobbies?"],
-        ['What is your contact information?'],
-        ["What is your summary?"],
+        # ['What is your contact information?'],
+        # ["What is your summary?"],
         ["What is your LinkedIn profile?"],
         # ["What is your GitHub profile?"],
         # ["What is your experience?"],


### PR DESCRIPTION
The example prompts for contact information and summary have been commented out in the ChatInterface configuration. This may be to prevent users from easily accessing personal or summary information.